### PR TITLE
Update slick 3.2.1 -> 3.3.2

### DIFF
--- a/framework/ixias-core/src/main/scala/ixias/persistence/jdbc/MySQLProfile.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/jdbc/MySQLProfile.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright ixias.net All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ */
+
+package ixias.persistence.jdbc
+
+import java.time.format.DateTimeFormatter
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
+
+import java.sql.{ PreparedStatement, ResultSet }
+
+import slick.jdbc.{ MySQLProfile => SlickMySQLProfile }
+
+trait MySQLProfile extends SlickMySQLProfile {
+  self =>
+
+  override val columnTypes: self.JdbcTypes = new CustomMySQLJdbcTypes
+
+  /**
+   * Copied from https://github.com/slick/slick/blob/v3.3.2/slick/src/main/scala/slick/jdbc/MySQLProfile.scala#L323-L345
+   */
+  @inline
+  private def stringToMySqlString(value: String): String =
+    value match {
+      case null => "NULL"
+      case _ =>
+        val sb = new StringBuilder
+        sb append '\''
+        for (c <- value) c match {
+          case '\'' => sb append "\\'"
+          case '"' => sb append "\\\""
+          case 0 => sb append "\\0"
+          case 26 => sb append "\\Z"
+          case '\b' => sb append "\\b"
+          case '\n' => sb append "\\n"
+          case '\r' => sb append "\\r"
+          case '\t' => sb append "\\t"
+          case '\\' => sb append "\\\\"
+          case _ => sb append c
+        }
+        sb append '\''
+        sb.toString
+    }
+
+  private class CustomMySQLJdbcTypes extends self.JdbcTypes {
+    private val formatter =
+      new DateTimeFormatterBuilder()
+        .append(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+        .optionalStart()
+        .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+        .optionalEnd()
+        .toFormatter()
+
+    override val localDateTimeType: LocalDateTimeJdbcType = new LocalDateTimeJdbcType {
+      override def sqlType: Int = java.sql.Types.VARCHAR
+
+      override def setValue(v: LocalDateTime, p: PreparedStatement, idx: Int): Unit =
+        p.setString(idx, if (v == null) null else v.toString)
+
+      override def getValue(r: ResultSet, idx: Int): LocalDateTime =
+        r.getString(idx) match {
+          case null => null
+          // Pass formatter to parse from string to date type
+          case dateString => LocalDateTime.parse(dateString, formatter)
+        }
+
+      override def updateValue(v: LocalDateTime, r: ResultSet, idx: Int) =
+        r.updateString(idx, if (v == null) null else v.toString)
+
+      override def valueToSQLLiteral(value: LocalDateTime): String =
+        stringToMySqlString(value.toString)
+    }
+  }
+}
+
+object MySQLProfile extends MySQLProfile

--- a/framework/ixias-core/src/main/scala/ixias/persistence/lifted/SlickQueryOps.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/lifted/SlickQueryOps.scala
@@ -21,21 +21,6 @@ final case class SlickQueryTransformer[E, U, C[_]](val self: Query[E, U, C]) ext
       case None        => if (0 < cursor.offset) self.drop(cursor.offset) else self
       case Some(limit) => self.drop(cursor.offset).take(limit)
     }
-
-  //-- [ Slick3.3 features ] ---------------------------------------------------
-  /**
-   * Applies the given filter, if the Option value is defined.
-   * If the value is None, the filter will not be part of the query.
-   */
-  def filterOpt[V, T : CanBeQueryCondition](optValue: Option[V])(f: (E, V) => T): Query[E, U, C] =
-    optValue.map(v => self.withFilter(a => f(a, v))).getOrElse(self)
-
-  /**
-   * Applies the given filter function, if the boolean parameter `p` evaluates to true.
-   * If not, the filter will not be part of the query.
-   */
-  def filterIf[T : CanBeQueryCondition](p: Boolean)(f: E => T): Query[E, U, C] =
-    if (p) self.withFilter(f) else self
 }
 
 final case class SlickQueryTransformerId[T <: ixias.model.@@[_, _], U, C[_]](

--- a/framework/ixias-core/src/main/scala/ixias/persistence/lifted/SlickQueryOps.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/lifted/SlickQueryOps.scala
@@ -9,7 +9,7 @@
 package ixias.persistence.lifted
 
 import slick.ast.{ TypedType, Library }
-import slick.lifted.{ Rep, Query, FunctionSymbolExtensionMethods, CanBeQueryCondition }
+import slick.lifted.{ Rep, Query, FunctionSymbolExtensionMethods }
 import ixias.persistence.model.Cursor
 
 import scala.language.higherKinds

--- a/framework/ixias-core/src/test/scala/ixias/persistence/jdbc/MySQLProfileTest.scala
+++ b/framework/ixias-core/src/test/scala/ixias/persistence/jdbc/MySQLProfileTest.scala
@@ -17,7 +17,11 @@ import ixias.persistence.SlickRepository
 
 class MySQLProfileTest extends Specification with AfterSpec {
 
-  implicit val driver = slick.jdbc.MySQLProfile
+  /**
+   * 標準の[[slick.jdbc.MySQLProfile]]を使用した場合LocalDateTimeのパースエラーとなることを確認
+   * [[slick.jdbc.MySQLProfile]]を拡張したものを使用した場合v3.2.3以前と同様の挙動になることを確認
+   */
+  implicit val driver = ixias.persistence.jdbc.MySQLProfile
   private val repository = new DateAndTimeTypesRepository
 
   private val testLocalDate = LocalDate.parse("2023-08-07")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
 
   val typesafeConfig = "com.typesafe" % "config" % "1.3.0"
 
-  val slick = "com.typesafe.slick" %% "slick" % "3.2.1"
+  val slick = "com.typesafe.slick" %% "slick" % "3.3.2"
 
   val shade = "io.monix" %% "shade" % "1.9.5"
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -7,7 +7,7 @@
 
 object ScalaVersions {
   val scala212 = "2.12.18"
-  val scala213 = "2.13.18"
+  val scala213 = "2.13.11"
   val scala3 = "3.3.0"
 }
 


### PR DESCRIPTION
## アップグレードガイド
### [3.2.1 -> 3.2.2](https://scala-slick.org/doc/3.2.2/upgrade.html#support-for-java.time-columns)
要対応特になし

### [3.2.2 -> 3.2.3](https://scala-slick.org/doc/3.2.3/upgrade.html#support-for-java.time-columns)
要対応特になし

### [3.2.3 -> 3.3.0](https://scala-slick.org/doc/3.3.0/upgrade.html#support-for-java.time-columns)
java.timeカラムのサポート対応を行う必要がある

- 公式推奨対応として既存のslick.jdbc.MySQLProfileを拡張して変換処理を任意のものに変える
- https://github.com/nextbeat-dev/ixias/pull/11 でテストコードを追記しバージョンアップ後も同様の結果になることを確認する
- LocalDateTime使用時にDB格納前と格納後で値が変わってしまう問題に関しては、NBではms単位で扱わないといけない要件がないため考慮しないこととする。またms単位を扱う必要がある場合はVARCHARなどの文字列として扱ってもらう。
- `java.time.Instant`, `java.time.OffsetTime`, `java.time.OffsetDateTime`, `java.time.ZonedDateTime`に関してはNBではカラムの型として使用していないかつ既存実装もサポートしていなかったため考慮しない。必要になった際にプロダクト単位かOSS単位でのサポートが必要か検討した上で実装を行う。

### [3.3.0 -> 3.3.1](https://scala-slick.org/doc/3.3.1/upgrade.html#support-for-java.time-columns)
要対応特になし

### [3.3.1 -> 3.3.2](https://scala-slick.org/doc/3.3.2/upgrade.html#support-for-java.time-columns)
要対応特になし

## リリースノート
対応が必要な変更があったバージョンのみ記載する

<details>
<summary>3.3.0</summary>
https://github.com/slick/slick/releases/tag/v3.3.0

**要対応**
- [x] filterOptとfilterIfを に追加しましたQuery
  - IxiaSで独自実装していたものを削除
</details>