### PR TITLE
shadeを使用した実装を別プロジェクトに切り出す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
           java-version: 8
           cache: sbt
 
+      - name: Deprecated project compile
+        run: sbt '++ ${{ matrix.scala }}' ixias-cache/compile
+
       - name: Set up Docker
         run: docker-compose -f framework/ixias-core/src/test/docker/docker-compose.yml up -d
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: docker-compose -f framework/ixias-core/src/test/docker/docker-compose.yml down
 
       - name: Compress target directories
-        run: tar cf targets.tar framework/ixias-aws-sns/target target/ixias-aws/target framework/ixias-mail/target framework/ixias-aws-s3/target framework/ixias-play-scalate/target framework/ixias-play-auth/target target/ixias-play/target framework/ixias-play-core/target framework/ixias-aws-qldb/target framework/ixias-core/target target project/target
+        run: tar cf targets.tar framework/ixias-aws-sns/target target/ixias-aws/target framework/ixias-mail/target framework/ixias-cache/target framework/ixias-aws-s3/target framework/ixias-play-scalate/target framework/ixias-play-auth/target target/ixias-play/target framework/ixias-play-core/target framework/ixias-aws-qldb/target framework/ixias-core/target target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v3

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,10 @@ ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin(java8))
 
 ThisBuild / githubWorkflowBuildPreamble ++= Seq(
   WorkflowStep.Run(
+    List("sbt '++ ${{ matrix.scala }}' ixias-cache/compile"),
+    name = Some("Deprecated project compile")
+  ),
+  WorkflowStep.Run(
     List("docker-compose -f framework/ixias-core/src/test/docker/docker-compose.yml up -d"),
     name = Some("Set up Docker")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -94,6 +94,12 @@ lazy val ixiasPlayAuth = IxiaSProject("ixias-play-auth", "framework/ixias-play-a
   .settings(libraryDependencies += play)
   .dependsOn(ixiasCore, ixiasPlayCore)
 
+// IxiaS Deprecated Libraries
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~
+lazy val ixiasCache = IxiaSProject("ixias-cache", "framework/ixias-cache")
+  .settings(libraryDependencies += shade)
+  .dependsOn(ixiasCore)
+
 // IxiaS Meta Packages
 //~~~~~~~~~~~~~~~~~~~~~
 lazy val ixias = IxiaSProject("ixias", ".")

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,6 @@ lazy val ixiasCore = IxiaSProject("ixias-core", "framework/ixias-core")
     typesafeConfig,
     slick,
     playJson,
-    shade,
     hikariCP,
     keyczar,
     uapScala,

--- a/framework/ixias-cache/src/main/scala/ixias/cache/persistence/ShadeRepository.scala
+++ b/framework/ixias-cache/src/main/scala/ixias/cache/persistence/ShadeRepository.scala
@@ -6,7 +6,7 @@
  * please view the LICENSE file that was distributed with this source code.
  */
 
-package ixias.persistence
+package ixias.cache.persistence
 
 import scala.reflect.ClassTag
 import scala.concurrent.Future
@@ -15,8 +15,9 @@ import shade.memcached.{ Memcached, MemcachedCodecs }
 
 import ixias.model.{ @@, Entity, EntityModel }
 import ixias.persistence.model.DataSourceName
-import ixias.persistence.backend.ShadeBackend
-import ixias.persistence.action.ShadeDBActionProvider
+import ixias.cache.persistence.backend.ShadeBackend
+import ixias.cache.persistence.action.ShadeDBActionProvider
+import ixias.persistence.{ Profile, Repository }
 import ixias.security.RandomStringToken
 
 /**

--- a/framework/ixias-cache/src/main/scala/ixias/cache/persistence/action/ShadeDBAction.scala
+++ b/framework/ixias-cache/src/main/scala/ixias/cache/persistence/action/ShadeDBAction.scala
@@ -6,13 +6,14 @@
  * please view the LICENSE file that was distributed with this source code.
  */
 
-package ixias.persistence.action
+package ixias.cache.persistence.action
 
 import scala.util.Failure
 import scala.concurrent.Future
 
-import ixias.persistence.ShadeProfile
 import ixias.persistence.model.DataSourceName
+import ixias.persistence.action.BasicAction
+import ixias.cache.persistence.ShadeProfile
 
 /**
  * The provider for `ShadeDBAction`

--- a/framework/ixias-cache/src/main/scala/ixias/cache/persistence/backend/ShadeBackend.scala
+++ b/framework/ixias-cache/src/main/scala/ixias/cache/persistence/backend/ShadeBackend.scala
@@ -6,18 +6,19 @@
  * please view the LICENSE file that was distributed with this source code.
  */
 
-package ixias.persistence.backend
+package ixias.cache.persistence.backend
 
 import scala.util.{ Success, Failure }
 import scala.concurrent.Future
 import shade.memcached.{ Memcached, Configuration }
 import ixias.persistence.model.DataSourceName
+import ixias.persistence.backend.{ BasicBackend, BasicDatabaseContainer }
 
 /**
  * The shade backend to handle the database and session.
  */
 case class ShadeBackend()
-   extends BasicBackend[Memcached] with ShadeConfig
+  extends BasicBackend[Memcached] with ShadeConfig
 {
   /** Get a Database instance from connection pool. */
   def getDatabase(implicit dsn: DataSourceName): Future[Database] = {

--- a/framework/ixias-cache/src/main/scala/ixias/cache/persistence/backend/ShadeConfig.scala
+++ b/framework/ixias-cache/src/main/scala/ixias/cache/persistence/backend/ShadeConfig.scala
@@ -6,12 +6,15 @@
  * please view the LICENSE file that was distributed with this source code.
  */
 
-package ixias.persistence.backend
+package ixias.cache.persistence.backend
+
+import java.util.concurrent.TimeUnit
 
 import scala.util.Try
-import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
+
 import ixias.persistence.model.DataSourceName
+import ixias.persistence.backend.BasicDatabaseConfig
 
 trait ShadeConfig extends BasicDatabaseConfig {
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -24,12 +24,12 @@ object BuildSettings {
     "-unchecked", // Enable additional warnings where generated code depends on assumptions.
     "-Xfatal-warnings", // Fail the compilation if there are any warnings.
     "-Xlint:-unused,_", // Enable recommended additional warnings.
-    "-Ywarn-adapted-args", // Warn if an argument list is modified to match the receiver.
     "-Ywarn-dead-code", // Warn when dead code is identified.
     "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
+    "-Ywarn-numeric-widen", // Warn when numerics are widened.
+    "-Ywarn-adapted-args", // Warn if an argument list is modified to match the receiver.
     "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
     "-Ywarn-nullary-override", // Warn when non-nullary overrides nullary, e.g. def foo() over def foo.
-    "-Ywarn-numeric-widen", // Warn when numerics are widened.
     "-Ypartial-unification" // Add support for partial unification of type constructors
   )
 


### PR DESCRIPTION
Scalaで実装されたmemcachedで使用できるクライアントがほとんど保守されておらず代替えがなかった。
そのためScalaのバージョンを更新することができない。
一度別プロジェクトに切り出して別途対応を進めることとする。

**想定される対応**
1. 廃止
2. Javaで探す (現状でもあまりない)
3. Redisなどに載せ替える