### PR TITLE
JDBC接続時にrewriteBatchedStatements=trueを有効にしてBULK INSERTでパフォーマンスを向上させるオプションを追加

### DIFF
--- a/framework/ixias-core/src/main/scala/ixias/persistence/backend/BasicDatabaseConfig.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/backend/BasicDatabaseConfig.scala
@@ -26,6 +26,7 @@ trait BasicDatabaseConfig {
   protected val CF_HOSTSPEC_DATABASE = "database"
   protected val CF_HOSTSPEC_SCHEMA   = "schema"
   protected val CF_HOSTSPEC_READONLY = "readonly"
+  protected val CF_REWRITE_BATCHED_STATEMENTS = "rewrite_batched_statements"
 
   /** The configuration */
   protected val config = Configuration()
@@ -83,4 +84,8 @@ trait BasicDatabaseConfig {
     }
     Try(opt)
   }
+
+  /** Get the flag for rewriteBatchedStatements. */
+  protected def getRewriteBatchedStatements(implicit dsn: DataSourceName): Boolean =
+    readValue(_.get[Option[Boolean]](CF_REWRITE_BATCHED_STATEMENTS)).getOrElse(false)
 }

--- a/framework/ixias-core/src/main/scala/ixias/persistence/backend/SlickBackend.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/backend/SlickBackend.scala
@@ -55,6 +55,9 @@ case class SlickBackend[P <: JdbcProfile](val driver: P)
         getHostSpecMaxPoolSize       map hconf.setMaximumPoolSize
         getHostSpecConnectionTimeout map hconf.setConnectionTimeout
         getHostSpecIdleTimeout       map hconf.setIdleTimeout
+        if (getRewriteBatchedStatements) {
+          hconf.addDataSourceProperty("rewriteBatchedStatements", true)
+        }
         HikariCPDataSource(new HikariDataSource(hconf), hconf)
       }
     }


### PR DESCRIPTION
## 概要

JDBC接続時に`rewriteBatchedStatements=true`を有効にする設定オプションを追加します。この変更により、複数のレコードを挿入する際に複数のINSERT文を実行するのではなく、BULK INSERTの文法を使用してパフォーマンスを向上させることができます。

## 詳細

- **機能:** JDBC接続文字列に`rewriteBatchedStatements=true`を設定する新しいオプションを追加しました。
- **利点:** この変更により、MySQLがバッチ挿入操作にBULK INSERTを使用できるようになり、実行される個々のINSERT文の数を減らすことでパフォーマンスを大幅に向上させることができます。
- **利用方法:** confファイルにおいて、hostspec.rewrite_batched_statements = trueと記述すると有効にできます。

## 参考

- https://nextbeat.slack.com/archives/C06B4RV1R/p1582877716088400
