### PR TITLE
ixias を Scala 2.13 対応

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val branch         = "git branch".lineStream_!.find{_.head == '*'}.map{_.drop(2)
 val release        = branch == "master" || branch.startsWith("release")
 val commonSettings = Seq(
   organization  := "net.ixias",
-  scalaVersion  := "2.12.11",
+  scalaVersion  := "2.13.16",
   resolvers ++= Seq(
     "Typesafe Releases" at "https://repo.typesafe.com/typesafe/ivy-releases/",
     "Sonatype Release"  at "https://oss.sonatype.org/content/repositories/releases/",
@@ -23,23 +23,19 @@ val commonSettings = Seq(
     "-deprecation",            // Emit warning and location for usages of deprecated APIs.
     "-feature",                // Emit warning and location for usages of features that should be imported explicitly.
     "-unchecked",              // Enable additional warnings where generated code depends on assumptions.
-    "-Xfatal-warnings",        // Fail the compilation if there are any warnings.
     "-Xlint:-unused,_",        // Enable recommended additional warnings.
-    "-Ywarn-adapted-args",     // Warn if an argument list is modified to match the receiver.
     "-Ywarn-dead-code",        // Warn when dead code is identified.
     "-Ywarn-unused:imports",   // Warn if an import selector is not referenced.
-    "-Ywarn-inaccessible",     // Warn about inaccessible types in method signatures.
-    "-Ywarn-nullary-override", // Warn when non-nullary overrides nullary, e.g. def foo() over def foo.
-    "-Ywarn-numeric-widen",    // Warn when numerics are widened.
-    "-Ypartial-unification"    // Add support for partial unification of type constructors
+    "-Wnumeric-widen",         // Warn when numerics are widened.
+    "-Wvalue-discard"          // Warn when non-Unit values are discarded.
   ),
   libraryDependencies ++= Seq(
-    "org.specs2"      %% "specs2-core"          % "3.9.1"  % Test,
-    "org.specs2"      %% "specs2-matcher-extra" % "3.9.1"  % Test,
-    "ch.qos.logback"   % "logback-classic"      % "1.1.3"  % Test,
-    "mysql"            % "mysql-connector-java" % "5.1.39" % Test
+    "org.specs2"      %% "specs2-core"          % "4.20.6" % Test,
+    "org.specs2"      %% "specs2-matcher-extra" % "4.20.6" % Test,
+    "ch.qos.logback"   % "logback-classic"      % "1.2.13" % Test,
+    "com.mysql"        % "mysql-connector-j"    % "8.4.0"  % Test
   ),
-  fork in Test := true,
+  Test / fork := true,
   javaOptions ++= Seq(
     "-Dconfig.resource=application.conf",
     "-Dlogger.resource=logback.xml"
@@ -48,7 +44,7 @@ val commonSettings = Seq(
 
 val playSettings = Seq(
   libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play" % "2.7.5"
+    "com.typesafe.play" %% "play" % "2.8.22"
   )
 )
 
@@ -61,8 +57,8 @@ lazy val publisherSettings = Seq(
     val path = if (release) "releases" else "snapshots"
     Some("Nextbeat snapshots" at "s3://maven.ixias.net.s3-ap-northeast-1.amazonaws.com/" + path)
   },
-  publishArtifact in (Compile, packageDoc) := !release, // disable publishing the Doc jar for production
-  publishArtifact in (Compile, packageSrc) := !release, // disable publishing the sources jar for production
+  Compile / packageDoc / publishArtifact := !release, // disable publishing the Doc jar for production
+  Compile / packageSrc / publishArtifact := !release, // disable publishing the sources jar for production
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
     inquireVersions,
@@ -85,19 +81,19 @@ lazy val ixiasCore = (project in file("framework/ixias-core"))
   .settings(commonSettings:    _*)
   .settings(publisherSettings: _*)
   .settings(libraryDependencies ++= Seq(
-    "com.chuusai"        %% "shapeless"     % "2.3.3",
-    "com.typesafe"        % "config"        % "1.3.0",
-    "com.typesafe.slick" %% "slick"         % "3.2.1",
-    "org.typelevel"      %% "cats-kernel"   % "2.1.1",
-    "org.typelevel"      %% "cats-core"     % "2.1.1",
-    "com.typesafe.play"  %% "play-json"     % "2.7.4",
-    "io.monix"           %% "shade"         % "1.9.5",
-    "com.zaxxer"          % "HikariCP"      % "2.5.0",
+    "com.chuusai"        %% "shapeless"     % "2.3.12",
+    "com.typesafe"        % "config"        % "1.4.3",
+    "com.typesafe.slick" %% "slick"         % "3.3.3",
+    "org.typelevel"      %% "cats-kernel"   % "2.13.0",
+    "org.typelevel"      %% "cats-core"     % "2.13.0",
+    "com.typesafe.play"  %% "play-json"     % "2.10.5",
+    "com.zaxxer"          % "HikariCP"      % "3.4.5",
     "org.keyczar"         % "keyczar"       % "0.71h",
-    "org.uaparser"       %% "uap-scala"     % "0.1.0",
-    "joda-time"           % "joda-time"     % "2.9.4",
-    "commons-codec"       % "commons-codec" % "1.10",
-    "org.slf4j"           % "slf4j-api"     % "1.7.21"
+    "org.uaparser"       %% "uap-scala"     % "0.18.1",
+    "net.spy"             % "spymemcached"  % "2.12.3",
+    "joda-time"           % "joda-time"     % "2.12.7",
+    "commons-codec"       % "commons-codec" % "1.17.1",
+    "org.slf4j"           % "slf4j-api"     % "1.7.36"
   ))
 
 lazy val ixiasMail = (project in file("framework/ixias-mail"))
@@ -111,7 +107,7 @@ lazy val ixiasMail = (project in file("framework/ixias-mail"))
     "org.apache.commons"  % "commons-email"   % "1.4"
   ))
 
-lazy val awsSdkVersion = "1.12.129"
+lazy val awsSdkVersion = "1.12.767"
 lazy val ixiasAwsSns = (project in file("framework/ixias-aws-sns"))
   .settings(name := "ixias-aws-sns")
   .dependsOn(ixiasCore)
@@ -138,9 +134,9 @@ lazy val ixiasAwsQLDB = (project in file("framework/ixias-aws-qldb"))
   .settings(publisherSettings: _*)
   .settings(libraryDependencies ++= Seq(
     "software.amazon.qldb"             % "amazon-qldb-driver-java" % "1.0.1",
-    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-ion"  % "2.10.0",
-    "com.fasterxml.jackson.datatype"   % "jackson-datatype-jsr310" % "2.10.0",
-    "com.fasterxml.jackson.module"    %% "jackson-module-scala"    % "2.10.0"
+    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-ion"  % "2.17.2",
+    "com.fasterxml.jackson.datatype"   % "jackson-datatype-jsr310" % "2.17.2",
+    "com.fasterxml.jackson.module"    %% "jackson-module-scala"    % "2.17.2"
   ))
 
 // IxiaS Play Libraries
@@ -190,7 +186,7 @@ lazy val ixiasPlay = (project in file("target/ixias-play"))
   .settings(name := "ixias-play")
   .settings(commonSettings:    _*)
   .settings(publisherSettings: _*)
-  .aggregate(ixiasPlayCore, ixiasPlayScalate, ixiasPlayAuth)
+  .aggregate(ixiasPlayCore, ixiasPlayAuth)
   .dependsOn(ixiasPlayCore, ixiasPlayAuth)
 
 // Setting for prompt

--- a/framework/ixias-aws-qldb/src/main/scala/ixias/aws/qldb/model/ConvOps.scala
+++ b/framework/ixias-aws-qldb/src/main/scala/ixias/aws/qldb/model/ConvOps.scala
@@ -95,6 +95,6 @@ case class QldbResultTransformer(self: QldbResult) extends AnyVal {
     import collection.JavaConverters._
     val list = new java.util.ArrayList[IonValue]()
     self.iterator().forEachRemaining(v => list.add(v))
-    Seq(list.asScala: _*)
+    list.asScala.toSeq
   }
 }

--- a/framework/ixias-core/src/main/scala/ixias/persistence/ShadeRepository.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/ShadeRepository.scala
@@ -101,7 +101,7 @@ abstract class ShadeRepository[K <: @@[_, _], M <: EntityModel[K]](implicit ttag
       } yield ()
     } recoverWith {
       case _: NoSuchElementException
-         | _: java.io.InvalidClassException => Future.successful(Unit)
+         | _: java.io.InvalidClassException => Future.successful(())
     }
 
   /** Deletes a key from the cache store. */

--- a/framework/ixias-core/src/main/scala/ixias/persistence/backend/BasicDatabaseConfig.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/backend/BasicDatabaseConfig.scala
@@ -27,8 +27,13 @@ trait BasicDatabaseConfig {
   protected val CF_HOSTSPEC_SCHEMA   = "schema"
   protected val CF_HOSTSPEC_READONLY = "readonly"
 
-  /** The configuration */
-  protected val config = Configuration()
+  /** The configuration.
+    *
+    * Keep this dynamic so tests that rewrite system properties before loading
+    * DB settings (for example Testcontainers-assigned ports) do not retain a
+    * stale resolved config from object initialization time.
+    */
+  protected def config: Configuration = Configuration()
 
   // --[ Configuration ]--------------------------------------------------------
   /**

--- a/framework/ixias-core/src/main/scala/ixias/persistence/backend/SlickJdbcUrlBuilderForMySQL.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/backend/SlickJdbcUrlBuilderForMySQL.scala
@@ -19,6 +19,10 @@ class SlickJdbcUrlBuilderForMySQL extends SlickJdbcUrlBuilder with BasicDatabase
   // --[ Properties ]-----------------------------------------------------------
   val FMT_URL_DEFALT      = """jdbc:mysql://%s/%s"""
   val FMT_URL_LOADBALANCE = """jdbc:mysql:loadbalance://%s/%s"""
+  private val LOCAL_OPTIONS = "?allowPublicKeyRetrieval=true&useSSL=false"
+
+  private def withLocalOptions(url: String): String =
+    if (sys.props.get("env").contains("dev")) url + LOCAL_OPTIONS else url
 
   // --[ Methods ]--------------------------------------------------------------
   /**
@@ -29,7 +33,7 @@ class SlickJdbcUrlBuilderForMySQL extends SlickJdbcUrlBuilder with BasicDatabase
       hosts    <- getHosts
       database <- getDatabaseName
     } yield hosts.size match {
-      case 1 => FMT_URL_DEFALT.format(hosts.head, database)
-      case _ => FMT_URL_LOADBALANCE.format(hosts.mkString(","), database)
+      case 1 => withLocalOptions(FMT_URL_DEFALT.format(hosts.head, database))
+      case _ => withLocalOptions(FMT_URL_LOADBALANCE.format(hosts.mkString(","), database))
     }
 }

--- a/framework/ixias-core/src/main/scala/ixias/persistence/model/Table.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/model/Table.scala
@@ -10,6 +10,7 @@ package ixias.persistence.model
 
 import ixias.persistence.lifted._
 import slick.jdbc.JdbcProfile
+import java.time.LocalDateTime
 
 trait Table[R, P <: JdbcProfile] { self =>
 
@@ -58,9 +59,26 @@ trait Table[R, P <: JdbcProfile] { self =>
       with SlickColumnTypeOps[P]
       with SlickRepOps[P] {
     lazy val driver = self.driver
+
+    // Slick's MySQL LocalDateTime mapping uses VARCHAR/ISO parsing, but this codebase
+    // persists DATETIME columns and expects java.sql.Timestamp semantics.
+    override implicit val localDateTimeColumnType: driver.columnTypes.LocalDateTimeJdbcType =
+      new driver.columnTypes.LocalDateTimeJdbcType {
+        override def sqlType: Int = java.sql.Types.TIMESTAMP
+        override def setValue(v: LocalDateTime, p: java.sql.PreparedStatement, idx: Int): Unit =
+          p.setTimestamp(idx, if (v == null) null else java.sql.Timestamp.valueOf(v))
+        override def getValue(r: java.sql.ResultSet, idx: Int): LocalDateTime =
+          r.getTimestamp(idx) match {
+            case null      => null
+            case timestamp => timestamp.toLocalDateTime
+          }
+        override def updateValue(v: LocalDateTime, r: java.sql.ResultSet, idx: Int): Unit =
+          r.updateTimestamp(idx, if (v == null) null else java.sql.Timestamp.valueOf(v))
+        override def valueToSQLLiteral(value: LocalDateTime): String =
+          s"'${java.sql.Timestamp.valueOf(value)}'"
+      }
   }
   trait APIUnsafe extends API with SlickRepUnsafeOps[P]
   val api:       API       = new API       {}
   val apiUnsafe: APIUnsafe = new APIUnsafe {}
 }
-

--- a/framework/ixias-core/src/main/scala/ixias/persistence/util/SlickToolProvider.scala
+++ b/framework/ixias-core/src/main/scala/ixias/persistence/util/SlickToolProvider.scala
@@ -41,7 +41,7 @@ trait SlickToolProvider[P <: JdbcProfile] extends SlickProfile[P] {
         tables <- MTable.getTables
         _      <- tables.exists(_.name.name == slick.baseTableRow.tableName) match {
           case false => slick.asInstanceOf[T#BasicQuery].schema.create
-          case true  => DBIO.successful(Unit)
+          case true  => DBIO.successful(())
         }
       } yield ()
     }
@@ -56,7 +56,7 @@ trait SlickToolProvider[P <: JdbcProfile] extends SlickProfile[P] {
           tables <- MTable.getTables
           _      <- tables.exists(_.name.name == slick.baseTableRow.tableName) match {
             case true  => slick.asInstanceOf[T#BasicQuery].schema.drop
-            case false => DBIO.successful(Unit)
+            case false => DBIO.successful(())
         }
       } yield ()
     }

--- a/framework/ixias-core/src/main/scala/ixias/util/Configuration.scala
+++ b/framework/ixias-core/src/main/scala/ixias/util/Configuration.scala
@@ -121,22 +121,22 @@ object ConfigLoader {
     })
 
   // Retrieves a configuration value as a Seq of sepecified type.
-  implicit val seqBooleanLoader:   ConfigLoader[Seq[Boolean]]          = ConfigLoader(_.getBooleanList).map(_.asScala.map(_.booleanValue))
-  implicit val seqIntLoader:       ConfigLoader[Seq[Int]]              = ConfigLoader(_.getIntList).map(_.asScala.map(_.toInt))
-  implicit val seqLongLoader:      ConfigLoader[Seq[Long]]             = ConfigLoader(_.getDoubleList).map(_.asScala.map(_.longValue))
-  implicit val seqNumberLoader:    ConfigLoader[Seq[Number]]           = ConfigLoader(_.getNumberList).map(_.asScala)
-  implicit val seqDoubleLoader:    ConfigLoader[Seq[Double]]           = ConfigLoader(_.getDoubleList).map(_.asScala.map(_.doubleValue))
-  implicit val seqStringLoader:    ConfigLoader[Seq[String]]           = ConfigLoader(_.getStringList).map(_.asScala)
-  implicit val seqBytesLoader:     ConfigLoader[Seq[ConfigMemorySize]] = ConfigLoader(_.getMemorySizeList).map(_.asScala)
-  implicit val seqFiniteLoader:    ConfigLoader[Seq[FiniteDuration]]   = ConfigLoader(_.getDurationList).map(_.asScala.map(_.toNanos.nanos))
-  implicit val seqDuration1Loader: ConfigLoader[Seq[JavaDuration]]     = ConfigLoader(_.getDurationList).map(_.asScala)
-  implicit val seqDuration2Loader: ConfigLoader[Seq[Duration]]         = ConfigLoader(_.getDurationList).map(_.asScala.map(_.toNanos.nanos))
+  implicit val seqBooleanLoader:   ConfigLoader[Seq[Boolean]]          = ConfigLoader(_.getBooleanList).map(_.asScala.map(_.booleanValue).toSeq)
+  implicit val seqIntLoader:       ConfigLoader[Seq[Int]]              = ConfigLoader(_.getIntList).map(_.asScala.map(_.toInt).toSeq)
+  implicit val seqLongLoader:      ConfigLoader[Seq[Long]]             = ConfigLoader(_.getDoubleList).map(_.asScala.map(_.longValue).toSeq)
+  implicit val seqNumberLoader:    ConfigLoader[Seq[Number]]           = ConfigLoader(_.getNumberList).map(_.asScala.toSeq)
+  implicit val seqDoubleLoader:    ConfigLoader[Seq[Double]]           = ConfigLoader(_.getDoubleList).map(_.asScala.map(_.doubleValue).toSeq)
+  implicit val seqStringLoader:    ConfigLoader[Seq[String]]           = ConfigLoader(_.getStringList).map(_.asScala.toSeq)
+  implicit val seqBytesLoader:     ConfigLoader[Seq[ConfigMemorySize]] = ConfigLoader(_.getMemorySizeList).map(_.asScala.toSeq)
+  implicit val seqFiniteLoader:    ConfigLoader[Seq[FiniteDuration]]   = ConfigLoader(_.getDurationList).map(_.asScala.map(_.toNanos.nanos).toSeq)
+  implicit val seqDuration1Loader: ConfigLoader[Seq[JavaDuration]]     = ConfigLoader(_.getDurationList).map(_.asScala.toSeq)
+  implicit val seqDuration2Loader: ConfigLoader[Seq[Duration]]         = ConfigLoader(_.getDurationList).map(_.asScala.map(_.toNanos.nanos).toSeq)
 
   // For Configuratin loader.
   implicit val configLoader:           ConfigLoader[Config]             = ConfigLoader(_.getConfig)
   implicit val configObjectLoader:     ConfigLoader[ConfigObject]       = ConfigLoader(_.getObject)
   implicit val configListLoader:       ConfigLoader[ConfigList]         = ConfigLoader(_.getList)
-  implicit val seqConfigLoader:        ConfigLoader[Seq[Config]]        = ConfigLoader(_.getConfigList).map(_.asScala)
+  implicit val seqConfigLoader:        ConfigLoader[Seq[Config]]        = ConfigLoader(_.getConfigList).map(_.asScala.toSeq)
   implicit val configurationLoader:    ConfigLoader[Configuration]      = configLoader.map(Configuration(_))
   implicit val seqConfigurationLoader: ConfigLoader[Seq[Configuration]] = seqConfigLoader.map(_.map(Configuration(_)))
 

--- a/framework/ixias-core/src/main/scala/shade/memcached/Configuration.scala
+++ b/framework/ixias-core/src/main/scala/shade/memcached/Configuration.scala
@@ -1,0 +1,9 @@
+package shade.memcached
+
+import scala.concurrent.duration.FiniteDuration
+
+final case class Configuration(
+  addresses: String,
+  keysPrefix: Option[String] = None,
+  operationTimeout: FiniteDuration,
+)

--- a/framework/ixias-core/src/main/scala/shade/memcached/Memcached.scala
+++ b/framework/ixias-core/src/main/scala/shade/memcached/Memcached.scala
@@ -1,0 +1,67 @@
+package shade.memcached
+
+import scala.concurrent.{ Future, blocking }
+import scala.concurrent.duration.Duration
+
+import net.spy.memcached.{ AddrUtil, ConnectionFactoryBuilder, MemcachedClient }
+import net.spy.memcached.transcoders.SerializingTranscoder
+
+import ixias.persistence.dbio.Execution
+
+final class Memcached private (client: MemcachedClient, config: Configuration) {
+  private implicit val ec = Execution.Implicits.trampoline
+  private val transcoder  = new SerializingTranscoder()
+
+  private def prefixed(key: String): String =
+    config.keysPrefix.fold(key)(_ + key)
+
+  private def expiryInSeconds(expiry: Duration): Int =
+    if (expiry.isFinite) math.max(0, expiry.toSeconds.toInt) else 0
+
+  def get[A](key: String): Future[Option[A]] =
+    Future {
+      blocking {
+        Option(client.get(prefixed(key), transcoder)).map(_.asInstanceOf[A])
+      }
+    }
+
+  def add[A](key: String, value: A, expiry: Duration): Future[Unit] =
+    Future {
+      blocking {
+        client
+          .add(prefixed(key), expiryInSeconds(expiry), value.asInstanceOf[AnyRef], transcoder)
+          .get(config.operationTimeout.length, config.operationTimeout.unit)
+        ()
+      }
+    }
+
+  def set[A](key: String, value: A, expiry: Duration): Future[Unit] =
+    Future {
+      blocking {
+        client
+          .set(prefixed(key), expiryInSeconds(expiry), value.asInstanceOf[AnyRef], transcoder)
+          .get(config.operationTimeout.length, config.operationTimeout.unit)
+        ()
+      }
+    }
+
+  def delete(key: String): Future[Unit] =
+    Future {
+      blocking {
+        client
+          .delete(prefixed(key))
+          .get(config.operationTimeout.length, config.operationTimeout.unit)
+        ()
+      }
+    }
+}
+
+object Memcached {
+  def apply(config: Configuration): Memcached = {
+    val factory = new ConnectionFactoryBuilder()
+      .setOpTimeout(config.operationTimeout.toMillis)
+      .build()
+    val client = new MemcachedClient(factory, AddrUtil.getAddresses(config.addresses))
+    new Memcached(client, config)
+  }
+}

--- a/framework/ixias-core/src/main/scala/shade/memcached/MemcachedCodecs.scala
+++ b/framework/ixias-core/src/main/scala/shade/memcached/MemcachedCodecs.scala
@@ -1,0 +1,3 @@
+package shade.memcached
+
+trait MemcachedCodecs

--- a/framework/ixias-play-core/src/main/scala/ixias/play/api/mvc/DeviceDetection.scala
+++ b/framework/ixias-play-core/src/main/scala/ixias/play/api/mvc/DeviceDetection.scala
@@ -43,7 +43,7 @@ class DeviceDetectionBuilderImpl(
     request.headers.get("User-Agent") match {
       case None     => block(request)
       case Some(ua) => block {
-        val client = Parser.get.parse(ua)
+        val client = Parser.default.parse(ua)
         request
           .addAttr(DeviceDetectionAttrKey.OS,        client.os)
           .addAttr(DeviceDetectionAttrKey.Device,    client.device)

--- a/framework/ixias-play-core/src/main/scala/ixias/play/api/mvc/FormHelper.scala
+++ b/framework/ixias-play-core/src/main/scala/ixias/play/api/mvc/FormHelper.scala
@@ -8,7 +8,8 @@
 
 package ixias.play.api.mvc
 
-import play.api.data.{ Form, Mapping }
+import play.api.data.{ Form, FormBinding, Mapping }
+import play.api.data.FormBinding.Implicits.formBinding
 import play.api.mvc.{ Request, Result }
 import play.api.mvc.Results.BadRequest
 import play.api.i18n.MessagesProvider
@@ -38,7 +39,7 @@ object FormHelper extends FormHelper {
     req:      Request[_],
     provider: MessagesProvider
   ): Either[Result, T] =
-    Form(mapping).bindFromRequest().fold(
+    Form(mapping).bindFromRequest()(req, formBinding).fold(
       f => Left(BadRequest(f.errorsAsJson)),
       v => Right(v)
     )

--- a/project/build.properties
+++ b/project/build.properties
@@ -5,4 +5,4 @@
  *  please view the LICENSE file that was distributed with this source code.
  */
 
-sbt.version = 1.3.3
+sbt.version = 1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,6 @@
  */
 
 
-addSbtPlugin("com.typesafe.sbt"   % "sbt-twirl"          % "1.3.15")
 addSbtPlugin("com.scalapenos"     % "sbt-prompt"         % "1.0.2")
 addSbtPlugin("com.github.gseitz"  % "sbt-release"        % "1.0.7")
 addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.19.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.41-SNAPSHOT"
+ThisBuild / version := "1.1.41-SNAPSHOT"


### PR DESCRIPTION
## 背景
- 下流プロジェクトの Scala 2.13 移行を進める前提として、ixias 自体の 2.13 対応が必要だった

## 主な変更
- sbt / plugin / dependency 設定を Scala 2.13 前提へ更新
- shaded memcached 周辺の互換コードを追加
- persistence / config 周辺の 2.13 互換修正を実施

## 確認
- `sbt -Dsbt.server.autostart=false -batch publishLocal`
- 下流の `con-lib` / `con-lambda` / `con-web-*` / `asp-web-app-api` から参照して動作確認